### PR TITLE
Change `default` behavior

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -101,7 +101,7 @@ export class Validator<T> {
    */
   default<D>(defaultValue: D): Validator<NonNullable<T> | D>
   default<D>(defaultValue: D): Validator<unknown> {
-    return this.map(v => (v === null || v === undefined ? defaultValue : v))
+    return this.nullable().map(v => (v === null || v === undefined ? defaultValue : v))
   }
 }
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -617,11 +617,13 @@ describe('validation core', () => {
     const validated2 = v.union(v.null, v.string).default('yes').validate(null)
     const validated3 = validator.validate('')
     const validated4 = validator.validate('hey')
+    const validated5 = v.string.default('yes').validate(undefined)
 
     expect(validated1.ok && validated1.value).toEqual('yes')
     expect(validated2.ok && validated2.value).toEqual('yes')
     expect(validated3.ok && validated3.value).toEqual('')
     expect(validated4.ok && validated4.value).toEqual('hey')
+    expect(validated5.ok && validated5.value).toEqual('yes')
   })
 
   it('can validate with a custom error string', () => {


### PR DESCRIPTION
Currently, only `.nullable()` and `.optional()` validator can default to a value.
However, as a user of the lib, I suppose `v.string.default(value)` will default to a value too.

This commit changes the behavior of `.default()` by callings `.nullable()` first.