### PR TITLE
Improve ts documentation

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -42,7 +42,14 @@ export class Validator<T> {
   }
 
   /**
-   * Chains this validator with another one, in series. A value must be valid for both validators.
+   * Chains this validator with another one, in series.
+   * The resulting value of the first validator will be the input of the second.
+   * 
+   * ```ts
+   * declare const stringToInt: Validator<number>
+   * declare const intToDate: Validator<Date>
+   * const stringToDate = stringToInt.then(intToDate)
+   * ```
    */
   then<B>(validator: Validator<B>): Validator<B> {
     const self = this


### PR DESCRIPTION
When a user navigates through the code and checking library declaration, the documentation of `then` is misleading.

It can be confusing to know if the initial value is used in the second validator or the result of the first one. To be sure, we need to look at the repository readme.

This commit improve this particular documentation and add an example.